### PR TITLE
build with cgo disabled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ clean:
 
 .PHONY: build
 build:
-	go build -o $(NAME) .
+	CGO_ENABLED=0 go build -o $(NAME) .
 
 .PHONY: image
 image:


### PR DESCRIPTION
```
/bin/acs-cve-prom-exporter: /lib64/libc.so.6: version `GLIBC_2.32' not found (required by /bin/acs-cve-prom-exporter)
/bin/acs-cve-prom-exporter: /lib64/libc.so.6: version `GLIBC_2.34' not found (required by /bin/acs-cve-prom-exporter)
```