### PR TITLE
APPSRE-10903-1: code refactor and error handling

### DIFF
--- a/cmd/exporter/exporter.go
+++ b/cmd/exporter/exporter.go
@@ -3,6 +3,9 @@ package exporter
 import (
 	"log"
 	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/app-sre/acs-cve-prom-exporter/internal/acs"
 	"github.com/prometheus/client_golang/prometheus"
@@ -11,16 +14,26 @@ import (
 
 func Run(endpoint string, token string) int {
 	reg := prometheus.NewRegistry()
-	signal := make(chan int)
-	go acs.Run(reg, endpoint, token, signal)
+	exit := make(chan struct{})
+	term := make(chan os.Signal, 1)
+	signal.Notify(term, os.Interrupt, syscall.SIGTERM)
+	go acs.Run(reg, endpoint, token, exit)
 
-	go func(signal chan int) {
+	go func(exit chan struct{}) {
 		http.Handle("/metrics", promhttp.HandlerFor(reg, promhttp.HandlerOpts{}))
 		log.Println("Beginning to serve on port :9090")
 		if err := http.ListenAndServe(":9090", nil); err != nil {
 			log.Println("Error starting server ", err)
-			signal <- 1
+			exit <- struct{}{}
 		}
-	}(signal)
-	return <-signal
+	}(exit)
+	for {
+		select {
+		case <-term:
+			log.Println("shutting down gracefully")
+			return 0
+		case <-exit:
+			return 1
+		}
+	}
 }

--- a/cmd/exporter/exporter.go
+++ b/cmd/exporter/exporter.go
@@ -9,12 +9,18 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
-func Run(endpoint string, token string) {
+func Run(endpoint string, token string) int {
 	reg := prometheus.NewRegistry()
+	signal := make(chan int)
+	go acs.Run(reg, endpoint, token, signal)
 
-	go acs.Run(reg, endpoint, token)
-
-	http.Handle("/metrics", promhttp.HandlerFor(reg, promhttp.HandlerOpts{}))
-	log.Println("Beginning to serve on port :9090")
-	log.Fatal(http.ListenAndServe(":9090", nil))
+	go func(signal chan int) {
+		http.Handle("/metrics", promhttp.HandlerFor(reg, promhttp.HandlerOpts{}))
+		log.Println("Beginning to serve on port :9090")
+		if err := http.ListenAndServe(":9090", nil); err != nil {
+			log.Println("Error starting server ", err)
+			signal <- 1
+		}
+	}(signal)
+	return <-signal
 }

--- a/internal/acs/metricsgen.go
+++ b/internal/acs/metricsgen.go
@@ -62,11 +62,7 @@ func (acs *Client) GetClusters() (*gql.GetClustersResponse, error) {
 		ctx,
 		acs.gqlClient,
 	)
-	if err != nil {
-		log.Printf("Error fetching data: %v", err)
-		return nil, err
-	}
-	return resp, nil
+	return resp, err
 }
 
 func (acs *Client) GetNamespaces(clusterId string) (*gql.GetNamespacesByClusterIDResponse, error) {
@@ -77,11 +73,7 @@ func (acs *Client) GetNamespaces(clusterId string) (*gql.GetNamespacesByClusterI
 		acs.gqlClient,
 		clusterId,
 	)
-	if err != nil {
-		log.Printf("Error fetching data: %v", err)
-		return nil, err
-	}
-	return resp, nil
+	return resp, err
 }
 
 func (acs *Client) GetNamespaceVulnerabilities(namespaceId string) (*gql.GetImageVulnerabilitiesByNamespaceIDResponse, error) {
@@ -92,11 +84,7 @@ func (acs *Client) GetNamespaceVulnerabilities(namespaceId string) (*gql.GetImag
 		acs.gqlClient,
 		namespaceId,
 	)
-	if err != nil {
-		log.Printf("Error fetching data: %v", err)
-		return nil, err
-	}
-	return resp, nil
+	return resp, err
 }
 
 func ConvertLabelsToString(labels prometheus.Labels) string {
@@ -166,13 +154,16 @@ func ProcessNamespaces(manager *collector.CollectorManager, metricsGenClient *Cl
 	log.Printf("Getting Clusters")
 	clusters, err := metricsGenClient.GetClusters()
 	if err != nil {
-		return fmt.Errorf("failed to get Clusters from acs : %v", err)
+		return fmt.Errorf("failed  getting Clusters from acs : %v", err)
 	}
-	var errs error = nil
+	var errs error
 	for _, cluster := range clusters.Clusters {
 
 		log.Printf("Getting Namespaces for cluster %s", cluster.Name)
-		namespaces, _ := metricsGenClient.GetNamespaces(cluster.Id)
+		namespaces, err := metricsGenClient.GetNamespaces(cluster.Id)
+		if err != nil {
+			return fmt.Errorf("failed getting Namespaces from acs: %v", err)
+		}
 		for _, namespace := range namespaces.Cluster.Namespaces {
 
 			// Don't!!!

--- a/internal/acs/metricsgen.go
+++ b/internal/acs/metricsgen.go
@@ -3,17 +3,19 @@ package acs
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
-	"github.com/Khan/genqlient/graphql"
-	"github.com/app-sre/acs-cve-prom-exporter/internal/collector"
-	"github.com/app-sre/acs-cve-prom-exporter/internal/gql"
-	"github.com/prometheus/client_golang/prometheus"
 	"log"
 	"net/http"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/Khan/genqlient/graphql"
+	"github.com/app-sre/acs-cve-prom-exporter/internal/collector"
+	"github.com/app-sre/acs-cve-prom-exporter/internal/gql"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 type bearerTokenTransport struct {
@@ -117,10 +119,13 @@ func ProcessVulnerabilities(
 	metricsGenClient *Client,
 	cluster gql.GetClustersClustersCluster,
 	namespace gql.GetNamespacesByClusterIDClusterNamespacesNamespace,
-) {
+) error {
 
 	log.Printf("Getting Vulnerabilities for cluster %s namespace %s", cluster.Name, namespace.Metadata.Name)
-	vulnerabilities, _ := metricsGenClient.GetNamespaceVulnerabilities(namespace.Metadata.Id)
+	vulnerabilities, err := metricsGenClient.GetNamespaceVulnerabilities(namespace.Metadata.Id)
+	if err != nil {
+		return err
+	}
 	for _, vulnerability := range vulnerabilities.Namespace.ImageVulnerabilities {
 		if !vulnerability.IsFixable {
 			continue
@@ -154,11 +159,16 @@ func ProcessVulnerabilities(
 			manager.AddCollector(index, collector.NewMyCollector(labels, vulnerability.Cvss))
 		}
 	}
+	return nil
 }
 
-func ProcessNamespaces(manager *collector.CollectorManager, metricsGenClient *Client) {
+func ProcessNamespaces(manager *collector.CollectorManager, metricsGenClient *Client) error {
 	log.Printf("Getting Clusters")
-	clusters, _ := metricsGenClient.GetClusters()
+	clusters, err := metricsGenClient.GetClusters()
+	if err != nil {
+		return fmt.Errorf("failed to get Clusters from acs : %v", err)
+	}
+	var errs error = nil
 	for _, cluster := range clusters.Clusters {
 
 		log.Printf("Getting Namespaces for cluster %s", cluster.Name)
@@ -168,13 +178,18 @@ func ProcessNamespaces(manager *collector.CollectorManager, metricsGenClient *Cl
 			// Don't!!!
 			// Don't even think about it!
 			// Calling this in goroutines will DoS the ACS Central API.
-			ProcessVulnerabilities(manager, metricsGenClient, cluster, namespace)
+			err = ProcessVulnerabilities(manager, metricsGenClient, cluster, namespace)
+			if err != nil {
+				errs = errors.Join(errs, fmt.Errorf("failed to process vulnerabilities: %v", err))
+				continue
+			}
 
 		}
 	}
+	return errs
 }
 
-func Run(reg *prometheus.Registry, endpoint string, token string) {
+func Run(reg *prometheus.Registry, endpoint string, token string, exitSignal chan int) {
 
 	metricsGenClient, _ := NewMetricsGenClient(
 		endpoint,
@@ -187,7 +202,12 @@ func Run(reg *prometheus.Registry, endpoint string, token string) {
 		newManager := collector.NewCollectorManager(reg)
 
 		log.Println("Beginning collection from ACS...")
-		ProcessNamespaces(newManager, metricsGenClient)
+		err := ProcessNamespaces(newManager, metricsGenClient)
+		if err != nil {
+			log.Println("Error processing Namespaces::", err)
+			exitSignal <- 1
+			break
+		}
 		log.Println("Collection completed.")
 
 		log.Println("Cleaning up old collectors...")

--- a/internal/acs/metricsgen.go
+++ b/internal/acs/metricsgen.go
@@ -33,7 +33,7 @@ type Client struct {
 	gqlClient graphql.Client
 }
 
-func NewMetricsGenClient(endpoint string, token string) (*Client, error) {
+func NewMetricsGenClient(endpoint string, token string) *Client {
 	transport := &bearerTokenTransport{
 		Base: &http.Transport{
 			TLSClientConfig: &tls.Config{
@@ -52,7 +52,7 @@ func NewMetricsGenClient(endpoint string, token string) (*Client, error) {
 
 	return &Client{
 		gqlClient: gqlClient,
-	}, nil
+	}
 }
 
 func (acs *Client) GetClusters() (*gql.GetClustersResponse, error) {
@@ -165,7 +165,10 @@ func ProcessNamespaces(manager *collector.CollectorManager, metricsGenClient *Cl
 			return fmt.Errorf("failed getting Namespaces from acs: %v", err)
 		}
 		for _, namespace := range namespaces.Cluster.Namespaces {
-
+			// if ImageVulnerabilityCount is zero skip it
+			if namespace.ImageVulnerabilityCount == 0 {
+				continue
+			}
 			// Don't!!!
 			// Don't even think about it!
 			// Calling this in goroutines will DoS the ACS Central API.
@@ -180,9 +183,9 @@ func ProcessNamespaces(manager *collector.CollectorManager, metricsGenClient *Cl
 	return errs
 }
 
-func Run(reg *prometheus.Registry, endpoint string, token string, exitSignal chan int) {
+func Run(reg *prometheus.Registry, endpoint string, token string, exitSignal chan struct{}) {
 
-	metricsGenClient, _ := NewMetricsGenClient(
+	metricsGenClient := NewMetricsGenClient(
 		endpoint,
 		token,
 	)
@@ -196,8 +199,8 @@ func Run(reg *prometheus.Registry, endpoint string, token string, exitSignal cha
 		err := ProcessNamespaces(newManager, metricsGenClient)
 		if err != nil {
 			log.Println("Error processing Namespaces::", err)
-			exitSignal <- 1
-			break
+			exitSignal <- struct{}{}
+			return
 		}
 		log.Println("Collection completed.")
 

--- a/internal/gql/generated.go
+++ b/internal/gql/generated.go
@@ -164,12 +164,18 @@ func (v *GetNamespacesByClusterIDCluster) GetNamespaces() []GetNamespacesByClust
 
 // GetNamespacesByClusterIDClusterNamespacesNamespace includes the requested fields of the GraphQL type Namespace.
 type GetNamespacesByClusterIDClusterNamespacesNamespace struct {
-	Metadata GetNamespacesByClusterIDClusterNamespacesNamespaceMetadata `json:"metadata"`
+	Metadata                GetNamespacesByClusterIDClusterNamespacesNamespaceMetadata `json:"metadata"`
+	ImageVulnerabilityCount int                                                        `json:"imageVulnerabilityCount"`
 }
 
 // GetMetadata returns GetNamespacesByClusterIDClusterNamespacesNamespace.Metadata, and is useful for accessing the field via an interface.
 func (v *GetNamespacesByClusterIDClusterNamespacesNamespace) GetMetadata() GetNamespacesByClusterIDClusterNamespacesNamespaceMetadata {
 	return v.Metadata
+}
+
+// GetImageVulnerabilityCount returns GetNamespacesByClusterIDClusterNamespacesNamespace.ImageVulnerabilityCount, and is useful for accessing the field via an interface.
+func (v *GetNamespacesByClusterIDClusterNamespacesNamespace) GetImageVulnerabilityCount() int {
+	return v.ImageVulnerabilityCount
 }
 
 // GetNamespacesByClusterIDClusterNamespacesNamespaceMetadata includes the requested fields of the GraphQL type NamespaceMetadata.
@@ -305,6 +311,7 @@ query GetNamespacesByClusterID ($clusterId: ID!) {
 				name
 				id
 			}
+			imageVulnerabilityCount
 		}
 	}
 }

--- a/internal/gql/genqlient.graphql
+++ b/internal/gql/genqlient.graphql
@@ -30,6 +30,7 @@ query GetNamespacesByClusterID ($clusterId: ID!) {
                 name
                 id
             }
+            imageVulnerabilityCount
         }
     }
 }

--- a/main.go
+++ b/main.go
@@ -21,6 +21,5 @@ func main() {
 	if token == "" {
 		log.Fatalf("Required var missing: %s", AcsToken)
 	}
-
 	os.Exit(exporter.Run(endpoint, token))
 }

--- a/main.go
+++ b/main.go
@@ -1,9 +1,10 @@
 package main
 
 import (
-	"github.com/app-sre/acs-cve-prom-exporter/cmd/exporter"
 	"log"
 	"os"
+
+	"github.com/app-sre/acs-cve-prom-exporter/cmd/exporter"
 )
 
 const (
@@ -13,13 +14,13 @@ const (
 
 func main() {
 	endpoint := os.Getenv(AcsEndpoint)
-	if len(endpoint) < 0 {
+	if endpoint == "" {
 		log.Fatalf("Required var missing: %s", AcsEndpoint)
 	}
 	token := os.Getenv(AcsToken)
-	if len(token) < 0 {
+	if token == "" {
 		log.Fatalf("Required var missing: %s", AcsToken)
 	}
 
-	exporter.Run(endpoint, token)
+	os.Exit(exporter.Run(endpoint, token))
 }


### PR DESCRIPTION
This PR is an effort to find the gaps in the exporter and make it production ready.
It consists of some code refactor and handling error which should fix current production issues with the exporter.
Also a new field `imageVulnerabilityCount` is added to query in order to get the number of image vulns for a namespace.
If this is zero there is no need to query `GetImageVulnerabilitiesByNamespaceID` for that particular namespace which should reduce the number of API calls made to acs.

The Implementaion above is similar to what we have for `prometheus-rds-exporter`, `blackbox-exporter` . Here we make use of different goroutines to handle the http endpoint and scrape the data from acs endpoint in async way. Signals are used to inform about failures and termination of the main go routine(https://github.com/app-sre/acs-cve-prom-exporter/blob/8cb1b84f0292feb6c43b3ff244ab05ee8901f241/cmd/exporter/exporter.go#L22-L39)